### PR TITLE
Add version information for Windows & Support cmake install param

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@
 
 cmake_minimum_required(VERSION 3.20)
 project(QSimpleUpdater
+    VERSION 1.0.0
+    DESCRIPTION "Automatic update library for Qt applications"
     LANGUAGES CXX
 )
 
@@ -98,6 +100,19 @@ set(FORMS
 )
 
 #-------------------------------------------------------------------------------
+# Windows version information resource
+#-------------------------------------------------------------------------------
+
+if(WIN32)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/etc/resources/version.rc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+        @ONLY
+    )
+    set(WINDOWS_RC ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+endif()
+
+#-------------------------------------------------------------------------------
 # Compile & link the library
 #-------------------------------------------------------------------------------
 
@@ -109,6 +124,7 @@ if(QSIMPLE_UPDATER_BUILD_SHARED)
         ${HEADERS}
         ${FORMS}
         ${QSU_RCC}
+        ${WINDOWS_RC}
     )
     target_compile_definitions(QSimpleUpdater PRIVATE QSU_SHARED)
 else()
@@ -121,8 +137,9 @@ else()
 endif()
 
 target_include_directories(QSimpleUpdater PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_link_libraries(QSimpleUpdater PUBLIC
@@ -130,6 +147,71 @@ target_link_libraries(QSimpleUpdater PUBLIC
     Qt${QSU_QT_VERSION_MAJOR}::Gui
     Qt${QSU_QT_VERSION_MAJOR}::Network
     Qt${QSU_QT_VERSION_MAJOR}::Widgets
+)
+
+#-------------------------------------------------------------------------------
+# Library properties
+#-------------------------------------------------------------------------------
+
+set_target_properties(QSimpleUpdater PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+# Add debug postfix on Windows to distinguish debug/release builds
+if(WIN32)
+    set_target_properties(QSimpleUpdater PROPERTIES
+        DEBUG_POSTFIX d
+    )
+endif()
+
+#-------------------------------------------------------------------------------
+# Installation rules
+#-------------------------------------------------------------------------------
+
+include(GNUInstallDirs)
+
+# Install library
+install(TARGETS QSimpleUpdater
+    EXPORT QSimpleUpdaterTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Install public headers
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/QSimpleUpdater.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QSimpleUpdater
+)
+
+# Install CMake config files
+install(EXPORT QSimpleUpdaterTargets
+    FILE QSimpleUpdaterTargets.cmake
+    NAMESPACE QSimpleUpdater::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QSimpleUpdater
+)
+
+# Generate and install package config file
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/QSimpleUpdaterConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/QSimpleUpdaterConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QSimpleUpdater
+)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/QSimpleUpdaterConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/QSimpleUpdaterConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/QSimpleUpdaterConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QSimpleUpdater
 )
 
 #-------------------------------------------------------------------------------

--- a/QSimpleUpdaterConfig.cmake.in
+++ b/QSimpleUpdaterConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/QSimpleUpdaterTargets.cmake")
+
+check_required_components(QSimpleUpdater)

--- a/etc/resources/version.rc.in
+++ b/etc/resources/version.rc.in
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014-2025 Alex Spataru <https://github.com/alex-spataru>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <windows.h>
+
+#define STRINGIFY2(x) #x
+#define STRINGIFY(x) STRINGIFY2(x)
+
+#define QSU_VERSION_NUMBER @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+#define QSU_VERSION_STRING STRINGIFY(@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@)
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+PRODUCTVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+FILEFLAGS 0x1L
+#else
+FILEFLAGS 0x0L
+#endif
+FILEOS 0x40004L
+FILETYPE 0x2L
+FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Alex Spataru"
+            VALUE "FileDescription", "QSimpleUpdater - Automatic update library for Qt applications"
+            VALUE "FileVersion", QSU_VERSION_STRING
+            VALUE "InternalName", "QSimpleUpdater"
+            VALUE "LegalCopyright", "Copyright (c) 2014-2025 Alex Spataru"
+            VALUE "ProductName", "QSimpleUpdater"
+            VALUE "ProductVersion", QSU_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
When compiled QSimpleUpdater on Windows platform, there is nothing version information of the built file.
This pr can make it.

<img width="776" height="1065" alt="image" src="https://github.com/user-attachments/assets/6050bcdc-e6ff-4aaa-8baa-0b3904ee37cd" />

And also, supports the cmake `install` command to setup the built file to different place.