### PR TITLE
add getMandatoryUpdate func for wrapped updater & set default install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,11 @@ endif()
 
 include(GNUInstallDirs)
 
+# Set default install directory to project's build/install if not specified
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE PATH "Install path prefix" FORCE)
+endif()
+
 # Install library
 install(TARGETS QSimpleUpdater
     EXPORT QSimpleUpdaterTargets

--- a/etc/resources/version.rc.in
+++ b/etc/resources/version.rc.in
@@ -46,7 +46,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "CompanyName", "Alex Spataru"
-            VALUE "FileDescription", "QSimpleUpdater - Automatic update library for Qt applications"
+            VALUE "FileDescription", "QSimpleUpdater - Automatic update library for Qt"
             VALUE "FileVersion", QSU_VERSION_STRING
             VALUE "InternalName", "QSimpleUpdater"
             VALUE "LegalCopyright", "Copyright (c) 2014-2025 Alex Spataru"

--- a/include/QSimpleUpdater.h
+++ b/include/QSimpleUpdater.h
@@ -82,6 +82,7 @@ public:
   QString getLatestVersion(const QString& url) const;
   QString getModuleVersion(const QString& url) const;
   QString getUserAgentString(const QString& url) const;
+  bool getMandatoryUpdate(const QString& url) const;
 
 public slots:
   void checkForUpdates(const QString& url);

--- a/src/QSimpleUpdater.cpp
+++ b/src/QSimpleUpdater.cpp
@@ -295,6 +295,20 @@ QString QSimpleUpdater::getUserAgentString(const QString& url) const
 }
 
 /**
+ * @brief Returns @c true if the update is mandatory for the Updater registered
+ *        with the given @a url.
+ *
+ * When mandatory, the application will quit if the user declines the update.
+ *
+ * @note If no Updater is registered with the given @a url, one will be created
+ *       automatically.
+ */
+bool QSimpleUpdater::getMandatoryUpdate(const QString& url) const
+{
+  return getUpdater(url)->mandatoryUpdate();
+}
+
+/**
  * @brief Instructs the Updater registered with the given @a url to download
  *        and interpret the update definitions file.
  *


### PR DESCRIPTION
1. Since the `updater` is private in `QSimpleUpdater`, the second one has the method `setMandatoryUpdate`, but hasn't the method `getMandatoryUpdate`. This pr add the function for it. Thus the final developer can decide what to do according to the flag.
2. The version info for windows is too log (my previous[pr](https://github.com/alex-spataru/QSimpleUpdater/pull/56)), I make it shorter now, so it can be displayed in the windows properties correctly.
3. The default install path in `CMakeLists` is missing, thus the built files will be installed to `C:\Program Files (x86)\QSimpleUpdater` (Windows platform), that is a little strange. I set it default to `${CMAKE_CURRENT_BINARY_DIR}/install`